### PR TITLE
[[FEAT]] Add support to plugin external Mocha compatible reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ a couple of Gherkin *reporters*, among other goodies.
 - [Reporters](#reporters)
   - [gherkin](#gherkin)
   - [gherkin-md](#gherkin-md)
+  - [external](#external-reporter)
 - [Running only selected tests](#running-only-selected-tests)
 - [Skipping tests](#skipping-tests)
 - [Manual tests](#manual-tests)
@@ -307,6 +308,7 @@ feature('Addition', function() {
 Tartare comes with two reporters:
 * **gherkin**: a console reporter that outputs a coloured description of your *features*, *scenarios* and *steps*.
 * **gherkin-md**: a Markdown reporter to upload the test description and results to GitHub.
+* **external**: plugin external mocha compatible reporter
 
 ### gherkin
 This is the default reporter. It prints the *feature*, *scenario* and *step* descriptions while they are being
@@ -367,6 +369,11 @@ $ tartare tests.js --reporter gherkin-md --reporter-options output=report.md,bug
 ```
 
 ![Markdown reporter output](http://telefonicaid.github.io/tartare/img/markdown-reporter.png)
+
+### external
+In addition to that you can plugin your own custom reporter as well.
+Simply set the useExternalReporter : true in tartareOpts in the config.
+
 
 ## Running only selected tests
 You can mark *features* or *scenarios* to be executed alone by using `.only`.

--- a/lib/tartare.js
+++ b/lib/tartare.js
@@ -59,6 +59,7 @@ function _convertToLowerCamelCase(token, index) {
 function Tartare(options) {
   this.options = options || {};
   this.options.reporter = this.options.reporter || 'gherkin';
+  this.options.useExternalReporter = this.options.useExternalReporter || false;
   this.options.timeout = this.options.timeout || 10000;
   this.options.bail = this.options.bail !== false;
   this.options.useColors = this.options.useColors !== false;
@@ -111,9 +112,11 @@ function Tartare(options) {
     }, this);
   }
 
+  var reporterModulePath = this.options.useExternalReporter === true ? this.options.reporter : './reporters/' + this.options.reporter;
+
   var mochaOpts = {
     ui: path.join(__dirname, './interfaces/gherkin'),
-    reporter: require('./reporters/' + this.options.reporter),
+    reporter: require(reporterModulePath),
     reporterOptions: this.options.reporterOptions,
     timeout: this.options.timeout,
     bail: this.options.bail,


### PR DESCRIPTION
Added support to use external reporters that are compatible with mocha. I am a big fan of mochawesome reporter and tartare syntax. So I combined all the goodness into one thing.
